### PR TITLE
Enable xcanvas with xeus-cpp-lite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,17 +12,6 @@ project(xcanvas)
 message(STATUS "Forcing tests build type to Release")
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
 
-if(EMSCRIPTEN)
-    set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
-    set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-s SIDE_MODULE=1")
-    set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-s SIDE_MODULE=1")
-    set(CMAKE_STRIP FALSE)
-
-    # Define the path to the shared library for use with CppInterOp dynamic loading
-    set(XCANVAS_CPPINTEROP_LIBRARY_PATH "\"/lib/${CMAKE_SHARED_LIBRARY_PREFIX}xcanvas${CMAKE_SHARED_LIBRARY_SUFFIX}\"")
-    message(STATUS "XCANVAS_CPPINTEROP_LIBRARY_PATH = ${XCANVAS_CPPINTEROP_LIBRARY_PATH}")
-endif()
-
 set(XCANVAS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(XCANVAS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
@@ -128,9 +117,6 @@ macro(xcanvas_create_target target_name linkage output_name)
     target_link_libraries(${target_name}
                           PUBLIC xproperty
                           PUBLIC ${XWIDGETS_TARGET_NAME})
-    if(EMSCRIPTEN)
-        set_target_properties(${target_name} PROPERTIES NO_SONAME 1)
-    endif()
 
     set_target_properties(${target_name} PROPERTIES
                           PUBLIC_HEADER "${XCANVAS_HEADERS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,17 @@ project(xcanvas)
 message(STATUS "Forcing tests build type to Release")
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
 
+if(EMSCRIPTEN)
+    set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
+    set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-s SIDE_MODULE=1")
+    set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-s SIDE_MODULE=1")
+    set(CMAKE_STRIP FALSE)
+
+    # Define the path to the shared library for use with CppInterOp dynamic loading
+    set(XCANVAS_CPPINTEROP_LIBRARY_PATH "\"/lib/${CMAKE_SHARED_LIBRARY_PREFIX}xcanvas${CMAKE_SHARED_LIBRARY_SUFFIX}\"")
+    message(STATUS "XCANVAS_CPPINTEROP_LIBRARY_PATH = ${XCANVAS_CPPINTEROP_LIBRARY_PATH}")
+endif()
+
 set(XCANVAS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(XCANVAS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
@@ -117,6 +128,9 @@ macro(xcanvas_create_target target_name linkage output_name)
     target_link_libraries(${target_name}
                           PUBLIC xproperty
                           PUBLIC ${XWIDGETS_TARGET_NAME})
+    if(EMSCRIPTEN)
+        set_target_properties(${target_name} PROPERTIES NO_SONAME 1)
+    endif()
 
     set_target_properties(${target_name} PROPERTIES
                           PUBLIC_HEADER "${XCANVAS_HEADERS}"
@@ -138,7 +152,11 @@ macro(xcanvas_create_target target_name linkage output_name)
     target_compile_features(${target_name} PRIVATE cxx_std_17)
 
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-        target_compile_options(${target_name} PUBLIC -Wunused-parameter -Wextra -Wreorder)
+        if(EMSCRIPTEN)
+            target_compile_options(${target_name} PRIVATE -fPIC)
+        else ()
+            target_compile_options(${target_name} PUBLIC -Wunused-parameter -Wextra -Wreorder)
+        endif()
     endif()
 
     if (${linkage_upper} STREQUAL "STATIC")

--- a/include/xcanvas/xcanvas_config.hpp
+++ b/include/xcanvas/xcanvas_config.hpp
@@ -56,4 +56,8 @@ inline std::string jupyter_canvas_semver()
 #include "xcanvas_config_cling.hpp"
 #endif
 
+#if defined(__CLANG_REPL__) && defined(__EMSCRIPTEN__)
+#include "xcanvas_config_cling.hpp"
+#endif
+
 #endif

--- a/include/xcanvas/xcanvas_config_cling.hpp.in
+++ b/include/xcanvas/xcanvas_config_cling.hpp.in
@@ -9,7 +9,19 @@
 #ifndef XCANVAS_CONFIG_CLING_HPP
 #define XCANVAS_CONFIG_CLING_HPP
 
+#ifdef __CLING__
+
 #pragma cling add_library_path(@XCANVAS_INSTALL_LIBRARY_DIR@)
 #pragma cling load("libxcanvas")
 
+#elif defined(__EMSCRIPTEN__) && defined(__CLANG_REPL__)
+
+#include <clang/Interpreter/CppInterOp.h>
+static bool _xcanvas_loaded = []() {
+    Cpp::LoadLibrary(@XCANVAS_CPPINTEROP_LIBRARY_PATH@, false);
+    return true;
+}();
+
 #endif
+
+#endif // XCANVAS_CONFIG_CLING_HPP

--- a/include/xcanvas/xcanvas_config_cling.hpp.in
+++ b/include/xcanvas/xcanvas_config_cling.hpp.in
@@ -18,7 +18,7 @@
 
 #include <clang/Interpreter/CppInterOp.h>
 static bool _xcanvas_loaded = []() {
-    Cpp::LoadLibrary(@XCANVAS_CPPINTEROP_LIBRARY_PATH@, false);
+    Cpp::LoadLibrary("/lib/@CMAKE_SHARED_LIBRARY_PREFIX@xcanvas@CMAKE_SHARED_LIBRARY_SUFFIX@", false);
     return true;
 }();
 


### PR DESCRIPTION
We have been using xcanvas in xeus-cpp-lite through a shared build (libxcanvas.so)

The patch can be found here : https://github.com/emscripten-forge/recipes/commit/3cf6d2a2b3f7c6c99f82513634a81205407fa5d3

This PR upstreams the patch involved and would need a release to get rid of the same on emscripten-forge.